### PR TITLE
Fixed an issue when retrieving filename in release builds.

### DIFF
--- a/src/Log4Mongo/BackwardCompatibility.cs
+++ b/src/Log4Mongo/BackwardCompatibility.cs
@@ -45,7 +45,7 @@ namespace Log4Mongo
 			// location information, if available
 			if(loggingEvent.LocationInformation != null)
 			{
-				toReturn["fileName"] = loggingEvent.LocationInformation.FileName;
+				toReturn["fileName"] = loggingEvent.LocationInformation.FileName??string.Empty;
 				toReturn["method"] = loggingEvent.LocationInformation.MethodName;
 				toReturn["lineNumber"] = loggingEvent.LocationInformation.LineNumber;
 				toReturn["className"] = loggingEvent.LocationInformation.ClassName;


### PR DESCRIPTION
The LocationInformation class doesn't not contain filename when running
in release build.
See
http://logging.apache.org/log4net/release/sdk/log4net.Core.LocationInfo.html
