### PR TITLE
Added support for complex property types

### DIFF
--- a/src/Log4Mongo.Tests/MongoDBAppenderTest.cs
+++ b/src/Log4Mongo.Tests/MongoDBAppenderTest.cs
@@ -76,6 +76,12 @@ namespace Log4Mongo.Tests
 			<name value='exception' />
 			<layout type='log4net.Layout.ExceptionLayout' />
 		</field>
+		<field>
+			<name value='customProperty' />
+			<layout type='log4net.Layout.RawPropertyLayout'>
+				<key value='customProperty' />
+			</layout>
+		</field>
 	</appender>
 	<root>
 		<level value='ALL' />
@@ -180,6 +186,31 @@ namespace Log4Mongo.Tests
 			var doc = _collection.FindOneAs<BsonDocument>();
 			doc.GetElement("numberProperty").Value.Should().Be.OfType<BsonInt32>();
 			doc.GetElement("dateProperty").Value.Should().Be.OfType<BsonDateTime>();
+		}
+
+		[Test]
+		public void Should_log_bsondocument()
+		{
+			var target = GetConfiguredLog();
+			var customProperty = new
+			{
+				Start = DateTime.Now,
+				Finished = DateTime.Now,
+				Input = new
+				{
+					Count = 100
+				},
+				Output = new
+				{
+					Count = 95
+				}
+			};
+			ThreadContext.Properties["customProperty"] = customProperty.ToBsonDocument();
+
+			target.Info("Finished");
+
+			var customPropertyFromDbJson = _collection.FindOneAs<BsonDocument>()["customProperty"].ToJson();
+			customProperty.ToJson().Should().Be.EqualTo(customPropertyFromDbJson);
 		}
 
 		[Test]

--- a/src/Log4Mongo/MongoDBAppender.cs
+++ b/src/Log4Mongo/MongoDBAppender.cs
@@ -110,8 +110,16 @@ namespace Log4Mongo
 			foreach(MongoAppenderFileld field in _fields)
 			{
 				object value = field.Layout.Format(log);
-				BsonValue bsonValue = BsonValue.Create(value);
-				doc.Add(field.Name, bsonValue);
+
+				if (value is BsonValue)
+				{
+					doc.Add(field.Name, value as BsonValue);
+				}
+				else
+				{
+					BsonValue bsonValue = BsonValue.Create(value);
+					doc.Add(field.Name, bsonValue);
+				}
 			}
 			return doc;
 		}


### PR DESCRIPTION
I needed support for logging structured complex data. Not just key/value fields.
The data had to be stored in mongodb as a document and not just a simple string value for indexing purposes.

For example 

``` csharp
var customProperty = new
{
    Start = startDate,
    Finished = finishedDate,
    Input = new
    {
        Count = 100
    },
    Output = new
    {
        Count = 95
    }
};
```

In my code I have a IRawLayout implementation that creates a BsonDocument but I needed to change the appender to not try to create a BsonValue using the factory method, otherwise it throws an exception.
The test I added shows how to use it when it is stored in log4net properties.
