### PR TITLE
Fixed issue with composite Properties being persisted with predicate "log4net:"

### DIFF
--- a/src/Log4Mongo.LoggingConsole/Log4Mongo.LoggingConsole.csproj
+++ b/src/Log4Mongo.LoggingConsole/Log4Mongo.LoggingConsole.csproj
@@ -36,13 +36,13 @@
     <Reference Include="log4net">
       <HintPath>..\..\lib\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=1.8.2.34, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+    <Reference Include="MongoDB.Bson, Version=1.9.1.221, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Bson.dll</HintPath>
+      <HintPath>..\..\lib\mongocsharpdriver.1.9.1\lib\net35\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.8.2.34, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+    <Reference Include="MongoDB.Driver, Version=1.9.1.221, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Driver.dll</HintPath>
+      <HintPath>..\..\lib\mongocsharpdriver.1.9.1\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Log4Mongo.LoggingConsole/packages.config
+++ b/src/Log4Mongo.LoggingConsole/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.0" targetFramework="net40" />
-  <package id="mongocsharpdriver" version="1.8.2" targetFramework="net40" />
+  <package id="mongocsharpdriver" version="1.9.1" targetFramework="net40" />
 </packages>

--- a/src/Log4Mongo.Tests/Log4Mongo.Tests.csproj
+++ b/src/Log4Mongo.Tests/Log4Mongo.Tests.csproj
@@ -34,14 +34,17 @@
     <Reference Include="log4net">
       <HintPath>..\..\lib\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson">
-      <HintPath>..\..\lib\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=1.9.1.221, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\mongocsharpdriver.1.9.1\lib\net35\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver">
-      <HintPath>..\..\lib\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=1.9.1.221, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\mongocsharpdriver.1.9.1\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\lib\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="SharpTestsEx">
       <HintPath>..\..\lib\SharpTestsEx.1.1.1\lib\SharpTestsEx.dll</HintPath>

--- a/src/Log4Mongo.Tests/packages.config
+++ b/src/Log4Mongo.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.0" />
-  <package id="mongocsharpdriver" version="1.8.2" targetFramework="net40" />
-  <package id="NUnit" version="2.6.2" targetFramework="net40" />
+  <package id="mongocsharpdriver" version="1.9.1" targetFramework="net40" />
+  <package id="NUnit" version="2.6.3" targetFramework="net40" />
   <package id="SharpTestsEx" version="1.1.1" />
 </packages>

--- a/src/Log4Mongo/BackwardCompatibility.cs
+++ b/src/Log4Mongo/BackwardCompatibility.cs
@@ -60,18 +60,18 @@ namespace Log4Mongo
 
 			// properties
 			PropertiesDictionary compositeProperties = loggingEvent.GetProperties();
-			if(compositeProperties != null && compositeProperties.Count > 0)
-			{
-				var properties = new BsonDocument();
-				foreach(DictionaryEntry entry in compositeProperties)
-				{
-					properties.Add(entry.Key.ToString(), entry.Value.ToString());
-				}
+		    if (compositeProperties == null || compositeProperties.Count <= 0) 
+                return toReturn;
+		    
+            var properties = new BsonDocument();
+		    foreach(DictionaryEntry entry in compositeProperties)
+		    {
+		        properties.Add(entry.Key.ToString().Replace("log4net:", ""), entry.Value.ToString());
+		    }
 
-				toReturn.Add("properties", properties);
-			}
+		    toReturn.Add("properties", properties);
 
-			return toReturn;
+		    return toReturn;
 		}
 
 		private static BsonDocument BuildExceptionBsonDocument(Exception ex)

--- a/src/Log4Mongo/BackwardCompatibility.cs
+++ b/src/Log4Mongo/BackwardCompatibility.cs
@@ -8,31 +8,31 @@ using log4net.Util;
 
 namespace Log4Mongo
 {
-	public class BackwardCompatibility
-	{
-		public static MongoDatabase GetDatabase(MongoDBAppender appender)
-		{
-			var port = appender.Port > 0 ? appender.Port : 27017;
-			var mongoConnectionString = new StringBuilder(string.Format("Server={0}:{1}", appender.Host ?? "localhost", port));
-			if(!string.IsNullOrEmpty(appender.UserName) && !string.IsNullOrEmpty(appender.Password))
-			{
-				// use MongoDB authentication
-				mongoConnectionString.AppendFormat(";Username={0};Password={1}", appender.UserName, appender.Password);
-			}
+    public class BackwardCompatibility
+    {
+        public static MongoDatabase GetDatabase(MongoDBAppender appender)
+        {
+            var port = appender.Port > 0 ? appender.Port : 27017;
+            var mongoConnectionString = new StringBuilder(string.Format("Server={0}:{1}", appender.Host ?? "localhost", port));
+            if (!string.IsNullOrEmpty(appender.UserName) && !string.IsNullOrEmpty(appender.Password))
+            {
+                // use MongoDB authentication
+                mongoConnectionString.AppendFormat(";Username={0};Password={1}", appender.UserName, appender.Password);
+            }
 
-			MongoServer connection = MongoServer.Create(mongoConnectionString.ToString()); // TODO Should be replaced with MongoClient, but this will change default for WriteConcern. See http://blog.mongodb.org/post/36666163412/introducing-mongoclient and http://docs.mongodb.org/manual/release-notes/drivers-write-concern
-			connection.Connect();
-			return connection.GetDatabase(appender.DatabaseName ?? "log4net_mongodb");
-		}
+            MongoServer connection = MongoServer.Create(mongoConnectionString.ToString()); // TODO Should be replaced with MongoClient, but this will change default for WriteConcern. See http://blog.mongodb.org/post/36666163412/introducing-mongoclient and http://docs.mongodb.org/manual/release-notes/drivers-write-concern
+            connection.Connect();
+            return connection.GetDatabase(appender.DatabaseName ?? "log4net_mongodb");
+        }
 
-		public static BsonDocument BuildBsonDocument(LoggingEvent loggingEvent)
-		{
-			if(loggingEvent == null)
-			{
-				return null;
-			}
+        public static BsonDocument BuildBsonDocument(LoggingEvent loggingEvent)
+        {
+            if (loggingEvent == null)
+            {
+                return null;
+            }
 
-			var toReturn = new BsonDocument {
+            var toReturn = new BsonDocument {
 				{"timestamp", loggingEvent.TimeStamp}, 
 				{"level", loggingEvent.Level.ToString()}, 
 				{"thread", loggingEvent.ThreadName}, 
@@ -43,51 +43,53 @@ namespace Log4Mongo
 				{"machineName", Environment.MachineName}
 			};
 
-			// location information, if available
-			if(loggingEvent.LocationInformation != null)
-			{
-				toReturn.Add("fileName", loggingEvent.LocationInformation.FileName);
-				toReturn.Add("method", loggingEvent.LocationInformation.MethodName);
-				toReturn.Add("lineNumber", loggingEvent.LocationInformation.LineNumber);
-				toReturn.Add("className", loggingEvent.LocationInformation.ClassName);
-			}
+            // location information, if available
+            if (loggingEvent.LocationInformation != null)
+            {
+                toReturn.Add("fileName", loggingEvent.LocationInformation.FileName);
+                toReturn.Add("method", loggingEvent.LocationInformation.MethodName);
+                toReturn.Add("lineNumber", loggingEvent.LocationInformation.LineNumber);
+                toReturn.Add("className", loggingEvent.LocationInformation.ClassName);
+            }
 
-			// exception information
-			if(loggingEvent.ExceptionObject != null)
-			{
-				toReturn.Add("exception", BuildExceptionBsonDocument(loggingEvent.ExceptionObject));
-			}
+            // exception information
+            if (loggingEvent.ExceptionObject != null)
+            {
+                toReturn.Add("exception", BuildExceptionBsonDocument(loggingEvent.ExceptionObject));
+            }
 
-			// properties
-			PropertiesDictionary compositeProperties = loggingEvent.GetProperties();
-		    if (compositeProperties == null || compositeProperties.Count <= 0) 
+            // properties
+            PropertiesDictionary compositeProperties = loggingEvent.GetProperties();
+            if (compositeProperties == null || compositeProperties.Count <= 0)
                 return toReturn;
-		    
+
             var properties = new BsonDocument();
-		    foreach(DictionaryEntry entry in compositeProperties)
-		    {
-		        properties.Add(entry.Key.ToString().Replace("log4net:", ""), entry.Value.ToString());
-		    }
+            foreach (DictionaryEntry entry in compositeProperties)
+            {
+                BsonValue value;
+                properties.Add(entry.Key.ToString().Replace("log4net:", ""),
+                    !BsonTypeMapper.TryMapToBsonValue(entry.Value, out value) ? entry.Value.ToBsonDocument() : value);
+            }
 
-		    toReturn.Add("properties", properties);
+            toReturn.Add("properties", properties);
 
-		    return toReturn;
-		}
+            return toReturn;
+        }
 
-		private static BsonDocument BuildExceptionBsonDocument(Exception ex)
-		{
-			var toReturn = new BsonDocument {
+        private static BsonDocument BuildExceptionBsonDocument(Exception ex)
+        {
+            var toReturn = new BsonDocument {
 				{"message", ex.Message}, 
 				{"source", ex.Source}, 
 				{"stackTrace", ex.StackTrace}
 			};
 
-			if(ex.InnerException != null)
-			{
-				toReturn.Add("innerException", BuildExceptionBsonDocument(ex.InnerException));
-			}
+            if (ex.InnerException != null)
+            {
+                toReturn.Add("innerException", BuildExceptionBsonDocument(ex.InnerException));
+            }
 
-			return toReturn;
-		}
-	}
+            return toReturn;
+        }
+    }
 }

--- a/src/Log4Mongo/Log4Mongo.csproj
+++ b/src/Log4Mongo/Log4Mongo.csproj
@@ -34,13 +34,13 @@
     <Reference Include="log4net">
       <HintPath>..\..\lib\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=1.8.2.34, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+    <Reference Include="MongoDB.Bson, Version=1.9.1.221, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Bson.dll</HintPath>
+      <HintPath>..\..\lib\mongocsharpdriver.1.9.1\lib\net35\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.8.2.34, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+    <Reference Include="MongoDB.Driver, Version=1.9.1.221, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Driver.dll</HintPath>
+      <HintPath>..\..\lib\mongocsharpdriver.1.9.1\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Log4Mongo/MongoDBAppender.cs
+++ b/src/Log4Mongo/MongoDBAppender.cs
@@ -102,14 +102,14 @@ namespace Log4Mongo
 
 		private MongoDatabase GetDatabase()
 		{
-			string connStr = GetConnectionString();
+			var connectionString = GetConnectionString();
 
-			if (string.IsNullOrWhiteSpace(connStr))
+			if (string.IsNullOrWhiteSpace(connectionString))
 			{
 				return BackwardCompatibility.GetDatabase(this);
 			}
 
-			MongoUrl url = MongoUrl.Create(connStr);
+			MongoUrl url = MongoUrl.Create(connectionString);
 
 			// TODO Should be replaced with MongoClient, but this will change default for WriteConcern.
 			// See http://blog.mongodb.org/post/36666163412/introducing-mongoclient

--- a/src/Log4Mongo/packages.config
+++ b/src/Log4Mongo/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.0" />
-  <package id="mongocsharpdriver" version="1.8.2" targetFramework="net40" />
+  <package id="mongocsharpdriver" version="1.9.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Simple replace on the key string. This was occuring on Identity, HostName, UserName in an MVC 5 app. Reversed the conditional logic for the composite properties to return out of the method if the opposite is true, code clarity.