### PR TITLE
Update readme.md to notify potential upper-case issue on TTL index

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ Appender configuration sample
 		<collectionName value="logs" />
 		
 		<field>
+			<!-- Note: this needs to be "timestamp" and NOT "Timestamp"  for the TTL index to work -->
 			<name value="timestamp" />
 			<layout type="log4net.Layout.RawTimeStampLayout" />
 		</field>


### PR DESCRIPTION
I've just noticed that if you use `<name value="Timestamp" />` the TTL index won't work.  It needs to be `<name value="timestamp" />`.  I'd like to point it out explicitly on the readme.