### PR TITLE
Modified MongoClient to work with SSL connection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,9 +29,14 @@ Appender configuration sample
 		-->
 		<connectionStringName value="mongo-log4net" />
 		<!-- 
+		The Friendly Name of the certificate. This value will be used if SSL is set to true
+		The default StoreLocation is LocalMachine and StoreName is My
+		-->	
+		<certificateFriendlyName value="Certificate Friendly Name"/>	
+		<!-- 
 		If set, a TTL (Time To Live) index will be created on the Timestamp field.  
 		Records older than this value will be deleted.
-		-->		
+		-->	
 		<expireAfterSeconds value="3600" />
 		<!-- 
 		Name of the collection in database

--- a/src/Log4Mongo.Tests/MongoDBAppenderTest.cs
+++ b/src/Log4Mongo.Tests/MongoDBAppenderTest.cs
@@ -582,5 +582,25 @@ namespace Log4Mongo.Tests
 
 			AssertThatCollectionIsNotCapped();
 		}
-	}
+
+        [Test]
+        public void Should_connect_over_ssl_connection_using_certificate_friendly_name()
+        {
+            XmlConfigurator.Configure(new MemoryStream(Encoding.UTF8.GetBytes(@"
+<log4net>
+	<appender name='MongoDBAppender' type='Log4Mongo.MongoDBAppender, Log4Mongo'>
+        <connectionString value='mongodb://username:password@10.1.1.12:27018/databasename?ssl=true;sslVerifyCertificate=false'/>
+        <certificateFriendlyName value='certificateFriendlyName' />
+    </appender>
+	<root>
+		<level value='ALL' />
+		<appender-ref ref='MongoDBAppender' />
+	</root>
+</log4net>
+")));
+            var target = LogManager.GetLogger("Test");
+
+            target.Info("a log");
+        }
+    }
 }


### PR DESCRIPTION
Code has been modified for MongoClient to work with SSL Connection. Certificate friendly name should be provided if ssl is set to true in mongo connectionstring. The default location for the certificate store is LocalMachine.