### PR TITLE
Support for BsonDocuments as values, allowing nested documents

### DIFF
--- a/src/Log4Mongo/MongoDBAppender.cs
+++ b/src/Log4Mongo/MongoDBAppender.cs
@@ -245,10 +245,15 @@ namespace Log4Mongo
 			var doc = new BsonDocument();
 			foreach (MongoAppenderFileld field in _fields)
 			{
-				object value = field.Layout.Format(log);
-				var bsonValue = value as BsonValue ?? BsonValue.Create(value);
-				doc.Add(field.Name, bsonValue);
-			}
+                object value = field.Layout.Format(log);
+                BsonValue bsonValue;
+                // if the object is complex and can't be mapped to a simple object, convert to bson document
+                if (!BsonTypeMapper.TryMapToBsonValue(value, out bsonValue))
+                {
+                    bsonValue = value.ToBsonDocument();
+                }
+                doc.Add(field.Name, bsonValue);
+            }
 			return doc;
 		}
 


### PR DESCRIPTION
BsonValue supports primitive types and ends up converting values to strings.  This leads to complex objects being represented within a single value as a string.  If the passed in value is a more complex object, convert it to a BsonDocument.

Addresses Issue #38 
